### PR TITLE
Fix NumPy 2.x uint8 overflow when reading channel count

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+This is a forked repo of [CNFreader](https://github.com/pbellino/CNFreader).
+
+---
 
 CNFreader
 =========

--- a/read_cnf.py
+++ b/read_cnf.py
@@ -457,7 +457,7 @@ def write_to_file(filename, dic,
     for k in keys_info:
         if k in dic:
             k_w_unit = k
-            if re.search('(?i)Real|Live\s*time', k):
+            if re.search(r'(?i)Real|Live\s*time', k):
                 k_w_unit += ' (s)'
             lines_info.append('{} {}: {}\n'.format(cmt_symb, k_w_unit, dic[k]))
         else:

--- a/read_cnf.py
+++ b/read_cnf.py
@@ -340,7 +340,7 @@ def get_channel_data(f, offs_param, offs_chan):
     """Read channel data."""
 
     # Total number of channels
-    n_channels = uint8_at(f, offs_param + 0x00ba) * 256
+    n_channels = int(uint8_at(f, offs_param + 0x00ba)) * 256
     # Data in each channel
     f.seek(offs_chan + 0x200)
     chan_data = np.fromfile(f, dtype='<u4', count=n_channels)


### PR DESCRIPTION
This PR fixes an OverflowError that can occur when reading CNF files with NumPy 2.x.

The error occurs in get_channel_data() while computing the total number of channels:

    OverflowError: Python integer 256 out of bounds for uint8

The failing line was:

    n_channels = uint8_at(f, offs_param + 0x00ba) * 256

uint8_at() returns a NumPy uint8 scalar. With NumPy 2.x, multiplying that scalar by 256 can fail because 256 cannot be represented as uint8.

This PR fixes the issue by converting the NumPy scalar to a Python int before multiplying:

    n_channels = int(uint8_at(f, offs_param + 0x00ba)) * 256

This preserves the intended calculation while making the code compatible with NumPy 2.x.

Related upstream issue:
https://github.com/pbellino/CNFreader/issues/4